### PR TITLE
fix for 'missing file link' errors in check

### DIFF
--- a/man/SeqVarGDSClass-class.Rd
+++ b/man/SeqVarGDSClass-class.Rd
@@ -30,7 +30,7 @@
 
 \description{
 	A \code{SeqVarGDSClass} object provides access to a GDS file containing
-Variant Call Format (VCF) data. It extends \code{\link[gdsfmt]{gds.class}}.
+Variant Call Format (VCF) data. It extends \code{\link{gds.class}}.
 }
 
 \details{
@@ -49,11 +49,11 @@ to create a \code{SeqVarGDSClass} object.
 		}
 		\item{}{
 			\code{ref(x)}:
-				Returns the reference alleles as a \code{\link[Biostrings]{DNAStringSet}}.
+				Returns the reference alleles as a \code{\link{DNAStringSet}}.
 		}
 		\item{}{
 			\code{alt(x)}:
-			Returns the alternate alleles as a \code{\link[Biostrings]{DNAStringSetList}}.
+			Returns the alternate alleles as a \code{\link{DNAStringSetList}}.
 		}
 		\item{}{
 			\code{qual(x)}:
@@ -69,7 +69,7 @@ to create a \code{SeqVarGDSClass} object.
 		}
 		\item{}{
 			\code{header(x)}:
-			Returns the header as a \code{\link[IRanges]{DataFrameList}}.
+			Returns the header as a \code{\link{DataFrameList}}.
 		}
 		\item{}{
 			\code{rowRanges(x)}:
@@ -106,7 +106,7 @@ to create a \code{SeqVarGDSClass} object.
 \author{Stephanie Gogarten, Xiuwen Zheng}
 
 \seealso{
-    \code{\link[gdsfmt]{gds.class}}, \code{\link{seqOpen}}
+    \code{\link{gds.class}}, \code{\link{seqOpen}}
 }
 
 \examples{

--- a/man/seqAsVCF.Rd
+++ b/man/seqAsVCF.Rd
@@ -26,12 +26,12 @@ return.
 The \pkg{VariantAnnotation} package should be loaded to explore this object.
 }
 \value{
-    A \code{\link[VariantAnnotation]{CollapsedVCF}} object.
+    A \code{\link[VariantAnnotation:VCF-class]{CollapsedVCF}} object.
 }
 
 \author{Stephanie Gogarten, Xiuwen Zheng}
 \seealso{
-    \code{\link[VariantAnnotation]{VCF}}
+    \code{\link[VariantAnnotation]{VCF-class}}
 }
 
 \examples{

--- a/man/seqGDS2VCF.Rd
+++ b/man/seqGDS2VCF.Rd
@@ -30,7 +30,7 @@ the export.
 
     If the filename extension is "gz", the gzip compression algorithm is used
 to compress the output data. When the Rsamtools package is installed, the
-exported file utilizes the bgzf format (\link[Rsamtools]{bgzip}, a variant of
+exported file utilizes the bgzf format (\link[Rsamtools:zip]{bgzip}, a variant of
 gzip format) allowing for fast indexing.
 }
 \references{

--- a/man/seqOpen.Rd
+++ b/man/seqOpen.Rd
@@ -14,7 +14,7 @@ seqOpen(gds.fn, readonly=TRUE, allow.duplicate=FALSE)
         with read-only mode when it has been opened in the same R session}
 }
 \value{
-    Return an object of class \code{\link[gdsfmt]{gds.class}}.
+    Return an object of class \code{\link{gds.class}}.
 }
 \details{
     It is strongly suggested to call \code{seqOpen} instead of

--- a/man/seqTranspose.Rd
+++ b/man/seqTranspose.Rd
@@ -11,7 +11,7 @@ seqTranspose(gdsfile, var.name, compress=NULL, verbose=TRUE)
     \item{gdsfile}{a \code{\link{SeqVarGDSClass}} object}
     \item{var.name}{the variable name with '/' as a separator}
     \item{compress}{the compression option used in
-        \code{\link[gdsfmt]{add.gdsn}}; or determine automatically
+        \code{\link{add.gdsn}}; or determine automatically
         if \code{NULL}}
     \item{verbose}{if \code{TRUE}, show information}
 }


### PR DESCRIPTION
This should resolve the "missing file link" warnings in the Bioconductor build report.