### PR TITLE
fixed asVCF unit test

### DIFF
--- a/inst/unitTests/test_asVCF.R
+++ b/inst/unitTests/test_asVCF.R
@@ -30,7 +30,11 @@ library(VariantAnnotation)
   ## tags with non-alphanumeric characters get ignored by scanBcfHeader
   meta.hdg <- meta(hdg)[grep("^[[:alnum:]]+$", row.names(meta(hdg))),,drop=FALSE]
   checkIdentical(meta(hdv)[rownames(meta.hdg),,drop=FALSE], meta.hdg)
-  checkIdentical(fixed(hdv), fixed(hdg))
+  ## VariantAnnotation now makes up a value for FILTER in the header even
+  ## if it was not present in original VCF header
+  for (i in intersect(names(fixed(hdv)), names(fixed(hdg)))) {
+      checkIdentical(fixed(hdv)[[i]], fixed(hdg)[[i]])
+  }
   checkIdentical(info(hdv), info(hdg))
   checkIdentical(geno(hdv), geno(hdg))
 }
@@ -164,7 +168,7 @@ test_filters <- function() {
   gdsobj <- seqOpen(gdsfile)
   samples <- seqGetData(gdsobj, "sample.id")[1:5]
   variants <- seqGetData(gdsobj, "variant.id")[1:10]
-  seqSetFilter(gdsobj, sample.id=samples, variant.id=variants)
+  seqSetFilter(gdsobj, sample.id=samples, variant.id=variants, verbose=FALSE)
 
   info <- c("AA", "AN")
   geno <- "GT"


### PR DESCRIPTION
This fixes one of the issues with failing unit tests introduced by VariantAnnotation 1.29.19. readVCF now creates a header entry for the "FILTER" field even if one was not present in the header of the original file. I have not replicated that behavior, but rather avoided checking for an exact match between header fields.